### PR TITLE
feat: :seedling: add initial discord client logic

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,7 @@
 # --- Required ---
 DISCORD_BOT_TOKEN= # Your Discord bot token
 DISCORD_CLIENT_ID= # Your Discord client ID
+DISCORD_GUILD_ID= # Your Discord server ID
 
 # --- Optional ---
 # LOG_LEVEL=info

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,5 +16,8 @@ jobs:
         with:
           bun-version-file: ".bun-version"
 
+      - name: 📦 Install Dependencies
+        run: bun install --frozen-lockfile
+
       - name: 🛠️ Check Build Success
         run: bun run build

--- a/biome.json
+++ b/biome.json
@@ -7,7 +7,7 @@
 	},
 	"files": {
 		"ignoreUnknown": false,
-		"ignore": []
+		"ignore": ["node_modules", "dist"]
 	},
 	"formatter": {
 		"enabled": true

--- a/bun.lock
+++ b/bun.lock
@@ -3,6 +3,9 @@
   "workspaces": {
     "": {
       "name": "discord-esport-manager-ts",
+      "dependencies": {
+        "discord.js": "^14.18.0",
+      },
       "devDependencies": {
         "@biomejs/biome": "^1.9.4",
         "@commitlint/cli": "^19.8.0",
@@ -73,6 +76,24 @@
 
     "@commitlint/types": ["@commitlint/types@19.8.0", "", { "dependencies": { "@types/conventional-commits-parser": "^5.0.0", "chalk": "^5.3.0" } }, "sha512-LRjP623jPyf3Poyfb0ohMj8I3ORyBDOwXAgxxVPbSD0unJuW2mJWeiRfaQinjtccMqC5Wy1HOMfa4btKjbNxbg=="],
 
+    "@discordjs/builders": ["@discordjs/builders@1.10.1", "", { "dependencies": { "@discordjs/formatters": "^0.6.0", "@discordjs/util": "^1.1.1", "@sapphire/shapeshift": "^4.0.0", "discord-api-types": "^0.37.119", "fast-deep-equal": "^3.1.3", "ts-mixer": "^6.0.4", "tslib": "^2.6.3" } }, "sha512-OWo1fY4ztL1/M/DUyRPShB4d/EzVfuUvPTRRHRIt/YxBrUYSz0a+JicD5F5zHFoNs2oTuWavxCOVFV1UljHTng=="],
+
+    "@discordjs/collection": ["@discordjs/collection@1.5.3", "", {}, "sha512-SVb428OMd3WO1paV3rm6tSjM4wC+Kecaa1EUGX7vc6/fddvw/6lg90z4QtCqm21zvVe92vMMDt9+DkIvjXImQQ=="],
+
+    "@discordjs/formatters": ["@discordjs/formatters@0.6.0", "", { "dependencies": { "discord-api-types": "^0.37.114" } }, "sha512-YIruKw4UILt/ivO4uISmrGq2GdMY6EkoTtD0oS0GvkJFRZbTSdPhzYiUILbJ/QslsvC9H9nTgGgnarnIl4jMfw=="],
+
+    "@discordjs/rest": ["@discordjs/rest@2.4.3", "", { "dependencies": { "@discordjs/collection": "^2.1.1", "@discordjs/util": "^1.1.1", "@sapphire/async-queue": "^1.5.3", "@sapphire/snowflake": "^3.5.3", "@vladfrangu/async_event_emitter": "^2.4.6", "discord-api-types": "^0.37.119", "magic-bytes.js": "^1.10.0", "tslib": "^2.6.3", "undici": "6.21.1" } }, "sha512-+SO4RKvWsM+y8uFHgYQrcTl/3+cY02uQOH7/7bKbVZsTfrfpoE62o5p+mmV+s7FVhTX82/kQUGGbu4YlV60RtA=="],
+
+    "@discordjs/util": ["@discordjs/util@1.1.1", "", {}, "sha512-eddz6UnOBEB1oITPinyrB2Pttej49M9FZQY8NxgEvc3tq6ZICZ19m70RsmzRdDHk80O9NoYN/25AqJl8vPVf/g=="],
+
+    "@discordjs/ws": ["@discordjs/ws@1.2.1", "", { "dependencies": { "@discordjs/collection": "^2.1.0", "@discordjs/rest": "^2.4.3", "@discordjs/util": "^1.1.0", "@sapphire/async-queue": "^1.5.2", "@types/ws": "^8.5.10", "@vladfrangu/async_event_emitter": "^2.2.4", "discord-api-types": "^0.37.119", "tslib": "^2.6.2", "ws": "^8.17.0" } }, "sha512-PBvenhZG56a6tMWF/f4P6f4GxZKJTBG95n7aiGSPTnodmz4N5g60t79rSIAq7ywMbv8A4jFtexMruH+oe51aQQ=="],
+
+    "@sapphire/async-queue": ["@sapphire/async-queue@1.5.5", "", {}, "sha512-cvGzxbba6sav2zZkH8GPf2oGk9yYoD5qrNWdu9fRehifgnFZJMV+nuy2nON2roRO4yQQ+v7MK/Pktl/HgfsUXg=="],
+
+    "@sapphire/shapeshift": ["@sapphire/shapeshift@4.0.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "lodash": "^4.17.21" } }, "sha512-d9dUmWVA7MMiKobL3VpLF8P2aeanRTu6ypG2OIaEv/ZHH/SUQ2iHOVyi5wAPjQ+HmnMuL0whK9ez8I/raWbtIg=="],
+
+    "@sapphire/snowflake": ["@sapphire/snowflake@3.5.3", "", {}, "sha512-jjmJywLAFoWeBi1W7994zZyiNWPIiqRRNAmSERxyg93xRGzNYvGjlZ0gR6x0F4gPRi2+0O6S71kOZYyr3cxaIQ=="],
+
     "@types/bun": ["@types/bun@1.2.9", "", { "dependencies": { "bun-types": "1.2.9" } }, "sha512-epShhLGQYc4Bv/aceHbmBhOz1XgUnuTZgcxjxk+WXwNyDXavv5QHD1QEFV0FwbTSQtNq6g4ZcV6y0vZakTjswg=="],
 
     "@types/conventional-commits-parser": ["@types/conventional-commits-parser@5.0.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-7uz5EHdzz2TqoMfV7ee61Egf5y6NkcO4FB/1iCCQnbeiI1F3xzv3vK5dBCXUCLQgGYS+mUeigK1iKQzvED+QnQ=="],
@@ -80,6 +101,8 @@
     "@types/node": ["@types/node@22.14.1", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-u0HuPQwe/dHrItgHHpmw3N2fYCR6x4ivMNbPHRkBVP4CvN+kiRrKHWk3i8tXiO/joPwXLMYvF9TTF0eqgHIuOw=="],
 
     "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
+
+    "@vladfrangu/async_event_emitter": ["@vladfrangu/async_event_emitter@2.4.6", "", {}, "sha512-RaI5qZo6D2CVS6sTHFKg1v5Ohq/+Bo2LZ5gzUEwZ/WkHhwtGTCB/sVLw8ijOkAUxasZ+WshN/Rzj4ywsABJ5ZA=="],
 
     "JSONStream": ["JSONStream@1.3.5", "", { "dependencies": { "jsonparse": "^1.2.0", "through": ">=2.2.7 <3" }, "bin": { "JSONStream": "./bin.js" } }, "sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ=="],
 
@@ -134,6 +157,10 @@
     "dargs": ["dargs@8.1.0", "", {}, "sha512-wAV9QHOsNbwnWdNW2FYvE1P56wtgSbM+3SZcdGiWQILwVjACCXDCI3Ai8QlCjMDB8YK5zySiXZYBiwGmNY3lnw=="],
 
     "debug": ["debug@4.4.0", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA=="],
+
+    "discord-api-types": ["discord-api-types@0.37.120", "", {}, "sha512-7xpNK0EiWjjDFp2nAhHXezE4OUWm7s1zhc/UXXN6hnFFU8dfoPHgV0Hx0RPiCa3ILRpdeh152icc68DGCyXYIw=="],
+
+    "discord.js": ["discord.js@14.18.0", "", { "dependencies": { "@discordjs/builders": "^1.10.1", "@discordjs/collection": "1.5.3", "@discordjs/formatters": "^0.6.0", "@discordjs/rest": "^2.4.3", "@discordjs/util": "^1.1.1", "@discordjs/ws": "^1.2.1", "@sapphire/snowflake": "3.5.3", "discord-api-types": "^0.37.119", "fast-deep-equal": "3.1.3", "lodash.snakecase": "4.1.1", "tslib": "^2.6.3", "undici": "6.21.1" } }, "sha512-SvU5kVUvwunQhN2/+0t55QW/1EHfB1lp0TtLZUSXVHDmyHTrdOj5LRKdR0zLcybaA15F+NtdWuWmGOX9lE+CAw=="],
 
     "dot-prop": ["dot-prop@5.3.0", "", { "dependencies": { "is-obj": "^2.0.0" } }, "sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q=="],
 
@@ -215,6 +242,8 @@
 
     "locate-path": ["locate-path@7.2.0", "", { "dependencies": { "p-locate": "^6.0.0" } }, "sha512-gvVijfZvn7R+2qyPX8mAuKcFGDf6Nc61GdvGafQsHL0sBIxfKzA+usWn4GFC/bk+QdwPUD4kWFJLhElipq+0VA=="],
 
+    "lodash": ["lodash@4.17.21", "", {}, "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="],
+
     "lodash.camelcase": ["lodash.camelcase@4.3.0", "", {}, "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA=="],
 
     "lodash.isplainobject": ["lodash.isplainobject@4.0.6", "", {}, "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA=="],
@@ -234,6 +263,8 @@
     "lodash.upperfirst": ["lodash.upperfirst@4.3.1", "", {}, "sha512-sReKOYJIJf74dhJONhU4e0/shzi1trVbSWDOhKYE5XV2O+H7Sb2Dihwuc7xWxVl+DgFPyTqIN3zMfT9cq5iWDg=="],
 
     "log-update": ["log-update@6.1.0", "", { "dependencies": { "ansi-escapes": "^7.0.0", "cli-cursor": "^5.0.0", "slice-ansi": "^7.1.0", "strip-ansi": "^7.1.0", "wrap-ansi": "^9.0.0" } }, "sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w=="],
+
+    "magic-bytes.js": ["magic-bytes.js@1.10.0", "", {}, "sha512-/k20Lg2q8LE5xiaaSkMXk4sfvI+9EGEykFS4b0CHHGWqDYU0bGUFSwchNOMA56D7TCs9GwVTkqe9als1/ns8UQ=="],
 
     "meow": ["meow@12.1.1", "", {}, "sha512-BhXM0Au22RwUneMPwSCnyhTOizdWoIEPU9sp0Aqa1PnDMR5Wv2FGXYDjuzJEIX+Eo2Rb8xuYe5jrnm5QowQFkw=="],
 
@@ -309,7 +340,13 @@
 
     "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
 
+    "ts-mixer": ["ts-mixer@6.0.4", "", {}, "sha512-ufKpbmrugz5Aou4wcr5Wc1UUFWOLhq+Fm6qa6P0w0K5Qw2yhaUoiWszhCVuNQyNwrlGiscHOmqYoAox1PtvgjA=="],
+
+    "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
     "typescript": ["typescript@5.8.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ=="],
+
+    "undici": ["undici@6.21.1", "", {}, "sha512-q/1rj5D0/zayJB2FraXdaWxbhWiNKDvu8naDT2dl1yTlvJp4BLtOcp2a5BvgGNQpYYJzau7tf1WgKv3b+7mqpQ=="],
 
     "undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
 
@@ -318,6 +355,8 @@
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 
     "wrap-ansi": ["wrap-ansi@9.0.0", "", { "dependencies": { "ansi-styles": "^6.2.1", "string-width": "^7.0.0", "strip-ansi": "^7.1.0" } }, "sha512-G8ura3S+3Z2G+mkgNRq8dqaFZAuxfsxpBB8OCTGRTCtp+l/v9nbFNmCUP1BZMts3G1142MsZfn6eeUKrr4PD1Q=="],
+
+    "ws": ["ws@8.18.1", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-RKW2aJZMXeMxVpnZ6bck+RswznaxmzdULiBr6KY7XkTnW8uvt0iT9H5DkHUChXrc+uurzwa0rVI16n/Xzjdz1w=="],
 
     "y18n": ["y18n@5.0.8", "", {}, "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="],
 
@@ -328,6 +367,10 @@
     "yargs-parser": ["yargs-parser@21.1.1", "", {}, "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="],
 
     "yocto-queue": ["yocto-queue@1.2.1", "", {}, "sha512-AyeEbWOu/TAXdxlV9wmGcR0+yh2j3vYPGOECcIj2S7MkrLyC7ne+oye2BKTItt0ii2PHk4cDy+95+LshzbXnGg=="],
+
+    "@discordjs/rest/@discordjs/collection": ["@discordjs/collection@2.1.1", "", {}, "sha512-LiSusze9Tc7qF03sLCujF5iZp7K+vRNEDBZ86FT9aQAv3vxMLihUvKvpsCWiQ2DJq1tVckopKm1rxomgNUc9hg=="],
+
+    "@discordjs/ws/@discordjs/collection": ["@discordjs/collection@2.1.1", "", {}, "sha512-LiSusze9Tc7qF03sLCujF5iZp7K+vRNEDBZ86FT9aQAv3vxMLihUvKvpsCWiQ2DJq1tVckopKm1rxomgNUc9hg=="],
 
     "cli-truncate/string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
 

--- a/package.json
+++ b/package.json
@@ -3,14 +3,15 @@
 	"type": "module",
 	"module": "src/index.ts",
 	"scripts": {
+		"build": "bun build src/index.ts --outdir ./dist --target bun",
 		"check": "biome check --write",
 		"check:ci": "biome ci .",
-		"build": "bun build src/index.ts --outdir ./dist --target bun",
 		"prepare": "husky",
+		"review:diff": "mkdir -p .temp && git diff main...HEAD > .temp/review.diff",
+		"start": "bun --watch src/index.ts",
 		"test": "bun test",
-		"test:watch": "bun test --watch",
 		"test:ci": "bun test --coverage",
-		"review:diff": "mkdir -p .temp && git diff main...HEAD > .temp/review.diff"
+		"test:watch": "bun test --watch"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "^1.9.4",
@@ -22,5 +23,8 @@
 	},
 	"peerDependencies": {
 		"typescript": "^5.0.0"
+	},
+	"dependencies": {
+		"discord.js": "^14.18.0"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -3,15 +3,15 @@
 	"type": "module",
 	"module": "src/index.ts",
 	"scripts": {
+		"start": "bun --watch src/index.ts",
 		"build": "bun build src/index.ts --outdir ./dist --target bun",
+		"test": "bun test",
+		"test:watch": "bun test --watch",
+		"test:ci": "bun test --coverage",
 		"check": "biome check --write",
 		"check:ci": "biome ci .",
 		"prepare": "husky",
-		"review:diff": "mkdir -p .temp && git diff main...HEAD > .temp/review.diff",
-		"start": "bun --watch src/index.ts",
-		"test": "bun test",
-		"test:ci": "bun test --coverage",
-		"test:watch": "bun test --watch"
+		"review:diff": "mkdir -p .temp && git diff main...HEAD > .temp/review.diff"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "^1.9.4",

--- a/src/core/CommandHandler.ts
+++ b/src/core/CommandHandler.ts
@@ -22,6 +22,7 @@ export default class CommandHandler {
 
 		this.commands.clear();
 
+		// TODO: Refactor this to load commands dynamically
 		this.commands.set(pingCommand.name, {
 			data: pingCommand,
 			execute: handlePing,
@@ -51,11 +52,6 @@ export default class CommandHandler {
 
 	async handleInteraction(interaction: Interaction) {
 		if (!interaction.isChatInputCommand()) return;
-
-		console.info(
-			LogMessages.CH_INFO_HANDLE_INTERACTION,
-			interaction.commandName,
-		);
 
 		const command = this.commands.get(interaction.commandName);
 

--- a/src/core/CommandHandler.ts
+++ b/src/core/CommandHandler.ts
@@ -1,0 +1,76 @@
+import { Collection, type Interaction, REST, Routes } from "discord.js";
+
+import pingCommand from "../modules/ping/commands/ping-command";
+import handlePing from "../modules/ping/handlers/ping-handler";
+import LogMessages from "./constants/LogMessages";
+import type { SlashCommand } from "./types/Commands";
+
+export default class CommandHandler {
+	commands = new Collection<string, SlashCommand>();
+
+	constructor(
+		private botToken: string,
+		private clientId: string,
+		private guildId?: string,
+	) {
+		this.initialiseCommands();
+		this.registerCommands();
+	}
+
+	initialiseCommands() {
+		console.info(LogMessages.CH_INFO_INIT_COMMANDS);
+
+		this.commands.clear();
+
+		this.commands.set(pingCommand.name, {
+			data: pingCommand,
+			execute: handlePing,
+		});
+	}
+
+	async registerCommands() {
+		console.info(LogMessages.CH_INFO_REGISTER_COMMANDS);
+		const rest = new REST({ version: "10" }).setToken(this.botToken);
+
+		const commandsValues = Array.from(this.commands.values());
+		const commandsData = commandsValues.map((cmd) => cmd.data.toJSON());
+
+		let route: `/${string}`;
+		let deploymentType: string;
+
+		if (this.guildId) {
+			route = Routes.applicationGuildCommands(this.clientId, this.guildId);
+			deploymentType = `Guild (${this.guildId})`;
+		} else {
+			route = Routes.applicationCommands(this.clientId);
+			deploymentType = "Global";
+		}
+
+		await rest.put(route, { body: commandsData });
+	}
+
+	async handleInteraction(interaction: Interaction) {
+		if (!interaction.isChatInputCommand()) return;
+
+		console.info(
+			LogMessages.CH_INFO_HANDLE_INTERACTION,
+			interaction.commandName,
+		);
+
+		const command = this.commands.get(interaction.commandName);
+
+		if (!command) {
+			console.error(
+				LogMessages.CH_ERROR_COMMAND_NOT_FOUND,
+				interaction.commandName,
+			);
+			return;
+		}
+
+		console.info(
+			LogMessages.CH_INFO_HANDLE_INTERACTION,
+			interaction.commandName,
+		);
+		await command.execute(interaction);
+	}
+}

--- a/src/core/client.ts
+++ b/src/core/client.ts
@@ -1,0 +1,5 @@
+import { Client, GatewayIntentBits } from "discord.js";
+
+export default new Client({
+	intents: [GatewayIntentBits.Guilds, GatewayIntentBits.GuildMessages],
+});

--- a/src/core/client.ts
+++ b/src/core/client.ts
@@ -1,5 +1,5 @@
 import { Client, GatewayIntentBits } from "discord.js";
 
 export default new Client({
-	intents: [GatewayIntentBits.Guilds, GatewayIntentBits.GuildMessages],
+	intents: [GatewayIntentBits.Guilds],
 });

--- a/src/core/constants/LogMessages.ts
+++ b/src/core/constants/LogMessages.ts
@@ -1,0 +1,10 @@
+export default {
+	MAIN_INFO_BOT_START: "Starting bot...",
+	MAIN_INFO_BOT_READY: "Bot is ready.",
+	MAIN_INFO_BOT_SHUTDOWN: "Shutting down bot...",
+
+	CH_INFO_INIT_COMMANDS: "Initialising commands...",
+	CH_INFO_REGISTER_COMMANDS: "Registering commands...",
+	CH_INFO_HANDLE_INTERACTION: "Handling interaction:",
+	CH_ERROR_COMMAND_NOT_FOUND: "Command not found:",
+};

--- a/src/core/types/Commands.ts
+++ b/src/core/types/Commands.ts
@@ -1,0 +1,12 @@
+import type {
+	CacheType,
+	ChatInputCommandInteraction,
+	SlashCommandBuilder,
+} from "discord.js";
+
+export interface SlashCommand {
+	data: Omit<SlashCommandBuilder, "addSubcommand" | "addSubcommandGroup">;
+	execute: (
+		interaction: ChatInputCommandInteraction<CacheType>,
+	) => Promise<void>;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ const GUILD_ID = process.env.DISCORD_GUILD_ID;
 		throw new Error("Missing required environment variable: DISCORD_CLIENT_ID");
 
 	try {
+		// TODO: Implement a logger library
 		console.info(LogMessages.MAIN_INFO_BOT_START);
 		client.on(Events.Error, console.error);
 		client.on(Events.Warn, console.warn);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,48 @@
-console.log("Hello via Bun!");
+import { Events } from "discord.js";
+import CommandHandler from "./core/CommandHandler";
+import client from "./core/client";
+import LogMessages from "./core/constants/LogMessages";
+
+const BOT_TOKEN = process.env.DISCORD_BOT_TOKEN;
+const CLIENT_ID = process.env.DISCORD_CLIENT_ID;
+const GUILD_ID = process.env.DISCORD_GUILD_ID;
+
+(async () => {
+	if (!BOT_TOKEN)
+		throw new Error("Missing required environment variable: DISCORD_BOT_TOKEN");
+	if (!CLIENT_ID)
+		throw new Error("Missing required environment variable: DISCORD_CLIENT_ID");
+
+	try {
+		console.info(LogMessages.MAIN_INFO_BOT_START);
+		client.on(Events.Error, console.error);
+		client.on(Events.Warn, console.warn);
+		const commandHandler = new CommandHandler(BOT_TOKEN, CLIENT_ID, GUILD_ID);
+
+		client.on(
+			Events.InteractionCreate,
+			commandHandler.handleInteraction.bind(commandHandler),
+		);
+
+		client.once(Events.ClientReady, () =>
+			console.info(LogMessages.MAIN_INFO_BOT_READY),
+		);
+
+		await client.login(BOT_TOKEN);
+	} catch (error) {
+		console.error(error);
+		process.exit(1);
+	}
+})();
+
+process.on("SIGINT", () => {
+	console.info(LogMessages.MAIN_INFO_BOT_SHUTDOWN);
+	client.destroy();
+	process.exit(0);
+});
+
+process.on("SIGTERM", () => {
+	console.info(LogMessages.MAIN_INFO_BOT_SHUTDOWN);
+	client.destroy();
+	process.exit(0);
+});

--- a/src/modules/ping/commands/ping-command.ts
+++ b/src/modules/ping/commands/ping-command.ts
@@ -1,0 +1,13 @@
+import {
+	ApplicationIntegrationType,
+	InteractionContextType,
+	SlashCommandBuilder,
+} from "discord.js";
+
+export default new SlashCommandBuilder()
+	.setName("ping")
+	// Temporary hard-coded text
+	// Will be replaced a translation function when i18n is implemented.
+	.setDescription("Replies with Pong! and shows bot latency.")
+	.setIntegrationTypes([ApplicationIntegrationType.GuildInstall])
+	.setContexts([InteractionContextType.Guild]);

--- a/src/modules/ping/handlers/ping-handler.ts
+++ b/src/modules/ping/handlers/ping-handler.ts
@@ -1,0 +1,22 @@
+import type { CacheType, ChatInputCommandInteraction } from "discord.js";
+import { MessageFlags } from "discord.js";
+
+export default async function handlePing(
+	interaction: ChatInputCommandInteraction<CacheType>,
+): Promise<void> {
+	// Temporary hard-coded text
+	// Will be replaced a translation function when i18n is implemented.
+	await interaction.reply({
+		content: "Pinging...",
+		flags: [MessageFlags.Ephemeral],
+	});
+
+	const latency = Date.now() - interaction.createdTimestamp;
+	const websocketHeartbeat = interaction.client.ws.ping;
+
+	// Temporary hard-coded text
+	// Will be replaced a translation function when i18n is implemented.
+	await interaction.editReply(
+		`Pong! 🏓\nRound trip latency: ${latency}ms\nWebSocket heartbeat: ${websocketHeartbeat}ms`,
+	);
+}


### PR DESCRIPTION
## Overview

Add initial discord client logic, with placeholder ping command

## Implementation

- ping command is just to test logic for client
- add initial structure for bot with core and modules
- set standard for log messages to go in const file
- i18n not implemented yet, so some temporary user strings