### PR TITLE
fix: :package: remove dynamic imports for build compatibility

### DIFF
--- a/src/core/commands.ts
+++ b/src/core/commands.ts
@@ -1,0 +1,5 @@
+import pingCommand from "../modules/ping/commands/ping.command";
+
+const commands = [pingCommand];
+
+export default commands;

--- a/src/core/commands.ts
+++ b/src/core/commands.ts
@@ -1,5 +1,8 @@
 import pingCommand from "../modules/ping/commands/ping.command";
 
+/**
+ * Commands array containing all commands to be registered.
+ */
 const commands = [pingCommand];
 
 export default commands;

--- a/src/core/constants/LogMessages.ts
+++ b/src/core/constants/LogMessages.ts
@@ -11,8 +11,6 @@ export default {
 	DEBUG_INIT_SERVICE_END: "Commands Service initialized.",
 	DEBUG_LOAD_MODULES_START: "Loading module(s)...",
 	DEBUG_LOAD_MODULES_END: "Module(s) loaded.",
-	DEBUG_LOAD_MODULE_START: "Loading '%s' module...",
-	DEBUG_LOAD_MODULE_END: "Module '%s' loaded.",
 	DEBUG_LOAD_COMMAND_FILE_START: "Loading '%s' command file...",
 	DEBUG_LOAD_COMMAND_FILE_END: "Command file '%s' loaded.",
 	DEBUG_REGISTER_COMMANDS_START: "Registering %s command(s)...",

--- a/src/core/services/commands.service.ts
+++ b/src/core/services/commands.service.ts
@@ -21,7 +21,6 @@ export default class CommandsService {
 	private readonly token: string;
 	private readonly clientId: string;
 	private readonly guildId?: string;
-	private readonly modulesPath = path.join(process.cwd(), "src", "modules");
 
 	constructor(token: string, clientId: string, guildId?: string) {
 		if (!token) throw new Error("CommandsService requires a bot token.");

--- a/src/core/services/commands.service.ts
+++ b/src/core/services/commands.service.ts
@@ -11,6 +11,7 @@ import {
 } from "discord.js";
 import { CommandNotFoundError } from "../../shared/errors/CommandNotFound";
 import logger from "../Logger";
+import commands from "../commands";
 import LogMessages from "../constants/LogMessages";
 import type { SlashCommand } from "../types/Commands";
 
@@ -33,110 +34,47 @@ export default class CommandsService {
 	}
 
 	/**
-	 * Loads commands dynamically and registers them with Discord.
+	 * Loads commands and registers them with Discord.
 	 */
 	async init() {
 		logger.debug(LogMessages.DEBUG_INIT_SERVICE_START);
 
-		await this.loadModules();
+		this.loadModules();
 		await this.registerCommands();
 
 		logger.debug(LogMessages.DEBUG_INIT_SERVICE_END);
 	}
 
 	/**
-	 * Orchestrates the loading of commands by finding modules and processing them.
+	 * Loads all modules and their commands.
 	 */
-	private async loadModules() {
+	private loadModules() {
 		logger.debug(LogMessages.DEBUG_LOAD_MODULES_START);
-
 		this.commands.clear();
 
-		const allEntries = await readdir(this.modulesPath, {
-			withFileTypes: true,
-		});
+		for (const command of commands) {
+			if (!command?.data?.name || typeof command.execute !== "function") {
+				logger.warn(
+					LogMessages.WARN_COMMAND_FILE_INVALID,
+					command?.data?.name || "unknown command",
+				);
+				continue;
+			}
+			if (this.commands.has(command.data.name)) {
+				logger.warn(
+					LogMessages.WARN_COMMAND_ALREADY_REGISTERED,
+					command.data.name,
+				);
+				continue;
+			}
+			this.commands.set(command.data.name, command);
+			logger.debug(LogMessages.DEBUG_LOAD_COMMAND_FILE_END, command.data.name);
+		}
 
-		const directories = allEntries.filter((dirent) => dirent.isDirectory());
-		const promises = directories.map(this.processModule.bind(this));
-
-		await Promise.all(promises);
-
-		logger.debug(LogMessages.DEBUG_LOAD_MODULES_END);
-
-		if (this.commands.size === 0)
+		if (this.commands.size === 0) {
 			logger.warn(LogMessages.WARN_NO_COMMANDS_RECOGNISED);
-	}
-
-	/**
-	 * Processes a single module directory to find and load commands.
-	 */
-	private async processModule(moduleDirent: Dirent) {
-		try {
-			logger.debug(LogMessages.DEBUG_LOAD_MODULE_START, moduleDirent.name);
-
-			const moduleName = moduleDirent.name;
-			const commandsPath = path.join(this.modulesPath, moduleName, "commands");
-			try {
-				const stats = await stat(commandsPath);
-				const commandsDirExists = stats.isDirectory();
-
-				if (!commandsDirExists) {
-					logger.debug(LogMessages.DEBUG_NO_COMMANDS_FOUND, moduleName);
-					return;
-				}
-			} catch (error) {
-				logger.debug(LogMessages.DEBUG_NO_COMMANDS_FOUND, moduleName);
-				return;
-			}
-
-			const commandFiles = await readdir(commandsPath);
-			for (const file of commandFiles) {
-				if (!(file.endsWith(".command.ts") || file.endsWith(".command.js"))) {
-					logger.warn(LogMessages.WARN_COMMAND_FILE_NOT_RECOGNISED, file);
-					continue;
-				}
-
-				const filePath = path.join(commandsPath, file);
-				await this.loadCommandFile(filePath);
-			}
-
-			logger.debug(LogMessages.DEBUG_LOAD_MODULE_END, moduleDirent.name);
-		} catch (error) {
-			logger.error(error, LogMessages.ERROR_LOAD_MODULE, moduleDirent.name);
 		}
-	}
-
-	/**
-	 * Loads, validates, and stores a single command from its file path.
-	 */
-	private async loadCommandFile(filePath: string) {
-		try {
-			const fileName = path.basename(filePath);
-			logger.debug(LogMessages.DEBUG_LOAD_COMMAND_FILE_START, fileName);
-
-			const fileUrl = pathToFileURL(filePath).href;
-
-			const commandModule = await import(fileUrl);
-			const command = commandModule.default;
-
-			if (!command.data.name || !command.execute) {
-				logger.warn(LogMessages.WARN_COMMAND_FILE_INVALID, fileName);
-				return;
-			}
-
-			const slashCommand = command as SlashCommand;
-
-			if (this.commands.has(slashCommand.data.name)) {
-				logger.warn(LogMessages.WARN_COMMAND_ALREADY_REGISTERED, fileName);
-				return;
-			}
-
-			this.commands.set(slashCommand.data.name, slashCommand);
-			logger.debug(LogMessages.DEBUG_LOAD_COMMAND_FILE_END, fileName);
-		} catch (error) {
-			const fileName = path.basename(filePath);
-			logger.error(error, LogMessages.ERROR_LOAD_COMMAND_FILE, fileName);
-		}
+		logger.debug(LogMessages.DEBUG_LOAD_MODULES_END);
 	}
 
 	/**


### PR DESCRIPTION
## Overview

Replace dynamic import of modules with static imports

## Implementation

- Build process doesn't copy modules directory, so we can't use the filesystem commands to build an import string
- Replaced with a static import array. Requires adding new commands but vastly simplifies the implementation
